### PR TITLE
Use newSessionWithOptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.0.4
+VERSION = 1.0.5
 LDFLAGS = -ldflags '-s -w'
 GOARCH = amd64
 linux: export GOOS=linux

--- a/main.go
+++ b/main.go
@@ -49,8 +49,10 @@ func main() {
 	fmt.Printf("Using access key %s from profile \"%s\".\n", creds.AccessKeyID, profileFlag)
 
 	// Create session
-	sess, err := session.NewSessionWithOptions(session.Options{Profile: profileFlag,})
-	check(err)
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Profile:           profileFlag,
+	}))
 
 	// sts get-caller-identity
 	stsClient := sts.New(sess)

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-const version = "1.0.4"
+const version = "1.0.5"
 
 func main() {
 	var yesFlag bool
@@ -49,7 +49,7 @@ func main() {
 	fmt.Printf("Using access key %s from profile \"%s\".\n", creds.AccessKeyID, profileFlag)
 
 	// Create session
-	sess, err := session.NewSession(&aws.Config{Credentials: credentialsProvider})
+	sess, err := session.NewSessionWithOptions(session.Options{Profile: profileFlag,})
 	check(err)
 
 	// sts get-caller-identity


### PR DESCRIPTION
Used newSessionWithOptions to get the profile instead of newSession this will allow you to correctly set the profile which for aws china accounts will be needed to set the region.