### PR TITLE
MFA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It will then wait for your confirmation before continuing.
 $ aws-rotate-key --help
 Usage of aws-rotate-key:
   -d	Delete old key without deactivation.
+  -mfa
+    	Use MFA.
   -profile string
     	The profile to use. (default "default")
   -version
@@ -81,6 +83,50 @@ The following IAM policy is enough for aws-rotate-key:
 ```
 
 Replace `AWS_ACCOUNT_ID` with your AWS account id.
+
+### Require MFA
+
+You can require MFA by adding a `Condition` clause. Please note that you
+have to use the `-mfa` option when running the program.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListMFADevices"
+            ],
+            "Resource": [
+                "arn:aws:iam::AWS_ACCOUNT_ID:user/${aws:username}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListAccessKeys",
+                "iam:GetAccessKeyLastUsed",
+                "iam:DeleteAccessKey",
+                "iam:CreateAccessKey",
+                "iam:UpdateAccessKey"
+            ],
+            "Resource": [
+                "arn:aws:iam::AWS_ACCOUNT_ID:user/${aws:username}"
+            ],
+            "Condition": {
+                "Bool": {
+                    "aws:MultiFactorAuthPresent": true
+                }
+            }
+        }
+    ]
+}
+```
+
+Note that this makes it hard to rotate the key using regular aws-cli commands,
+as it only supports MFA when assuming roles. You will still be able to use
+the AWS management console.
 
 ## Contribute
 


### PR DESCRIPTION
I actually coded this over a year ago, but didn't take the time to clean it up properly until now. I'm opening this as a PR to get comments on the implementation.

Most tools, like the aws-cli, require you to assume a role to use an MFA. But it is possible to use `sts:GetSessionToken` to just "add" an MFA to your non-MFA credentials ([official sample code here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_sample-code.html)).

I don't own a Gemalto device, but I think it would work for that too. It would probably also work for [SMS MFA](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_sms.html) (I didn't test), but that is being deprecated on February 1st, 2019. It definitely does not work with U2F, so I added a check for that.

I considered adding an `-mfa-device` option to optionally avoid the MFA lookup. We all know about the `mfa_serial` credentials option when assuming roles, but that isn't really the way it's meant to be used. It would be possible to find it in the file ourselves, but that's a lot of work. Anyway, I think we can require `iam:ListMFADevices` to be available without MFA, at least for the first release.

Let's keep it as simple as possible until there are feature requests to support more complicated scenarios.