### PR TITLE
Update AWS credentials in Maven settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.0.6
+VERSION = 1.0.7
 LDFLAGS = -ldflags '-s -w'
 GOARCH = amd64
 linux: export GOOS=linux
@@ -10,7 +10,10 @@ linux_arm64: export GOARCH=arm64
 darwin: export GOOS=darwin
 windows: export GOOS=windows
 
-all: linux linux_arm linux_arm64 darwin windows
+all: test linux linux_arm linux_arm64 darwin windows
+
+test:
+	go test -v ./...
 
 linux:
 	go build $(LDFLAGS)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/Fullscreen/aws-rotate-key
 
-require github.com/aws/aws-sdk-go v1.16.11
+require (
+	github.com/aws/aws-sdk-go v1.16.11
+	github.com/magiconair/properties v1.8.0
+	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,15 @@
 github.com/aws/aws-sdk-go v1.16.11 h1:g/c7gJeVyHoXCxM2fddS85bPGVkBF8s2q8t3fyElegc=
 github.com/aws/aws-sdk-go v1.16.11/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
+github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/main.go
+++ b/main.go
@@ -15,9 +15,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
+
+	"github.com/Fullscreen/aws-rotate-key/maven"
 )
 
-const version = "1.0.6"
+const version = "1.0.7"
 
 func main() {
 	var yesFlag bool
@@ -226,6 +228,18 @@ func main() {
 	err = ioutil.WriteFile(credentialsPath, []byte(credentialsText), 0600)
 	check(err)
 	fmt.Printf("Wrote new key pair to %s\n", credentialsPath)
+
+	// Update Maven settings
+	s := maven.FindSettings(os.Getenv("HOME"))
+	if s != nil {
+		accessKey := *respCreateAccessKey.AccessKey
+		err = s.Update(&creds, &credentials.Value{
+			AccessKeyID:     *accessKey.AccessKeyId,
+			SecretAccessKey: *accessKey.SecretAccessKey,
+		})
+		check(err)
+		fmt.Printf("Updated AWS credentials in Maven settings: %s\n", s)
+	}
 
 	// Deleting the key if flag is set, otherwise only deactivating
 	if deleteFlag {

--- a/maven/settings.go
+++ b/maven/settings.go
@@ -1,0 +1,40 @@
+package maven
+
+import (
+	"github.com/Fullscreen/aws-rotate-key/text/replacer"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/pkg/errors"
+	"os"
+)
+
+type Settings string
+
+func FindSettings(homeDir string) *Settings {
+	s := homeDir + "/.m2/settings.xml"
+
+	info, err := os.Stat(s)
+	if os.IsNotExist(err) || info.IsDir() {
+		return nil
+	}
+
+	return (*Settings)(&s)
+}
+
+func (s *Settings) Update(curr *credentials.Value, gen *credentials.Value) error {
+
+	r := replacer.New(map[string]string{
+		curr.AccessKeyID:     gen.AccessKeyID,
+		curr.SecretAccessKey: gen.SecretAccessKey,
+	})
+
+	err := r.RewriteFile(string(*s))
+	if err != nil {
+		return errors.Wrapf(err, "failed to update %s", s)
+	}
+
+	return nil
+}
+
+func (s *Settings) String() string {
+	return string(*s)
+}

--- a/maven/settings_test.go
+++ b/maven/settings_test.go
@@ -1,0 +1,105 @@
+package maven
+
+import (
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const settings = `<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+	<servers>
+		<server>
+			<id>test</id>
+			<username>AKIAJ2GVS75XDR4SOYTA</username>
+			<password>yRZFXie1R7J5IZziNnLVLLDDvsjwIrpNmdsygoqa</password>
+		</server>
+	</servers>
+</settings>
+`
+
+var (
+	curr = &credentials.Value{
+		AccessKeyID:     "AKIAJ2GVS75XDR4SOYTA",
+		SecretAccessKey: "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",
+	}
+
+	gen = &credentials.Value{
+		AccessKeyID:     "AKIAJWXHUQFWBJFLJMAQ",
+		SecretAccessKey: "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",
+	}
+)
+
+func TestFindSettings(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	assert.Nil(t, FindSettings(dir))
+
+	_, err = createFile(dir + "/.m2/settings.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotNil(t, FindSettings(dir))
+}
+
+func TestSettings_Update(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	f, err := createFile(dir + "/.m2/settings.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = f.WriteString(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = FindSettings(dir).Update(curr, gen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := readFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.False(t, strings.Contains(content, curr.AccessKeyID))
+	assert.False(t, strings.Contains(content, curr.SecretAccessKey))
+
+	assert.True(t, strings.Contains(content, gen.AccessKeyID))
+	assert.True(t, strings.Contains(content, gen.SecretAccessKey))
+}
+
+func createFile(path string) (*os.File, error) {
+	dir := filepath.Dir(path)
+
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.Create(path)
+}
+
+func readFile(path string) (string, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/text/replacer/replacer.go
+++ b/text/replacer/replacer.go
@@ -1,0 +1,40 @@
+package replacer
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+type Replacer strings.Replacer
+
+func New(pairs map[string]string) *Replacer {
+	s := make([]string, 0)
+	for k, v := range pairs {
+		s = append(s, k, v)
+	}
+	return (*Replacer)(strings.NewReplacer(s...))
+}
+
+func (r *Replacer) RewriteFile(filename string) error {
+	data, err := readFile(filename)
+	if err != nil {
+		return err
+	}
+	return writeFile(filename, r.replace(string(data)))
+}
+
+func (r *Replacer) replace(s string) string {
+	return (*strings.Replacer)(r).Replace(s)
+}
+
+func readFile(filename string) (string, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func writeFile(path string, content string) error {
+	return ioutil.WriteFile(path, []byte(content), 0600)
+}

--- a/text/replacer/replacer_test.go
+++ b/text/replacer/replacer_test.go
@@ -1,0 +1,38 @@
+package replacer
+
+import (
+	"github.com/magiconair/properties/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestRewriteFile(t *testing.T) {
+
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filename := f.Name()
+	defer os.Remove(filename)
+
+	_, err = f.WriteString("Hello, Alice!\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := New(map[string]string{"Alice": "Bob"})
+
+	err = r.RewriteFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, string(data), "Hello, Bob!\n")
+}


### PR DESCRIPTION
[Apache Maven](https://maven.apache.org/) a build tool used primarily for Java projects. To access private artifacts stored in an S3 bucket, it requires AWS credentials set in `~/.m2/settings.xml`.

This PR makes it so that every time you rotate AWS credentials with `aws-rotate-key`, it updates Maven settings accordingly.

See the following links for details:
- [How to Set Up a Private Maven Repository in Amazon S3](https://www.yegor256.com/2015/09/07/maven-repository-amazon-s3.html)