### PR TITLE
Support using a different profile for auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,12 +23,14 @@ func main() {
 	var yesFlag bool
 	var mfaFlag bool
 	var profileFlag string
+	var authProfileFlag string
 	var versionFlag bool
 	var deleteFlag bool
 	flag.BoolVar(&yesFlag, "y", false, `Automatic "yes" to prompts.`)
 	flag.BoolVar(&mfaFlag, "mfa", false, "Use MFA.")
 	flag.BoolVar(&deleteFlag, "d", false, "Delete old key without deactivation.")
 	flag.StringVar(&profileFlag, "profile", "default", "The profile to use.")
+	flag.StringVar(&authProfileFlag, "auth-profile", "", "Use a different profile to authenticate.")
 	flag.BoolVar(&versionFlag, "version", false, "Print version number")
 	flag.Parse()
 
@@ -52,6 +54,10 @@ func main() {
 	creds, err := credentialsProvider.Get()
 	check(err)
 	fmt.Printf("Using access key %s from profile \"%s\".\n", creds.AccessKeyID, profileFlag)
+
+	if authProfileFlag != "" {
+		profileFlag = authProfileFlag
+	}
 
 	// Read credentials file
 	bytes, err := ioutil.ReadFile(credentialsPath)


### PR DESCRIPTION
Add -auth-profile flag, for cases when an MFA-acquired temporary profile should be used for authentication, but a permament profile contains the key to be rotated. This removes the need to specify the `-mfa` switch, allowing aws-rotate-key to continue to be used in a cron job