### PR TITLE
Use GitHub Actions to provide binaries for every push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+on: [push]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@master
+      with:
+        go-version: 1.13
+    - uses: actions/checkout@master
+    - name: go build
+      run: |
+        GOOS=linux GOARCH=amd64       go build -o release/linux_amd64/aws-rotate-key
+        GOOS=linux GOARCH=arm GOARM=6 go build -o release/linux_arm/aws-rotate-key
+        GOOS=linux GOARCH=arm64       go build -o release/linux_arm64/aws-rotate-key
+        GOOS=darwin GOARCH=amd64      go build -o release/darwin_amd64/aws-rotate-key
+        GOOS=windows GOARCH=amd64     go build -o release/windows_amd64/aws-rotate-key.exe
+    - uses: actions/upload-artifact@master
+      with:
+        name: aws-rotate-key-linux_amd64-${{ github.sha }}
+        path: release/linux_amd64/aws-rotate-key
+    - uses: actions/upload-artifact@master
+      with:
+        name: aws-rotate-key-linux_arm-${{ github.sha }}
+        path: release/linux_arm/aws-rotate-key
+    - uses: actions/upload-artifact@master
+      with:
+        name: aws-rotate-key-linux_arm64-${{ github.sha }}
+        path: release/linux_arm64/aws-rotate-key
+    - uses: actions/upload-artifact@master
+      with:
+        name: aws-rotate-key-darwin_amd64-${{ github.sha }}
+        path: release/darwin_amd64/aws-rotate-key
+    - uses: actions/upload-artifact@master
+      with:
+        name: aws-rotate-key-windows_amd64-${{ github.sha }}
+        path: release/windows_amd64/aws-rotate-key.exe


### PR DESCRIPTION
This makes it easy for anyone to download binaries for builds that are being developed in feature branches, and also makes it easy to try out unreleased code in the master branch.

Annoyances:
- The zip file doesn't preserve the executable bit. So after downloading you have to run `chmod +x` on the file.
- The artifact UI is broken for long filenames (I wanted to put the commit hash in the zip filename).

Note:
- I decided to omit `-ldflags '-s -w'` to make the binaries more debuggable, but this makes the them bigger than the normal release binaries. What do people think about this?

Example on my fork: https://github.com/stefansundin/aws-rotate-key/actions

<img width="1011" src="https://user-images.githubusercontent.com/1991151/68641257-27ba3200-04bf-11ea-9a3b-7b71442d3a03.png">
