### PR TITLE
build: explicit the arch for all platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
 VERSION = 1.0.8
 LDFLAGS = -ldflags '-s -w' -gcflags=-trimpath=${PWD} -asmflags=-trimpath=${PWD}
 
-linux: export GOOS=linux
-linux: export GOARCH=amd64
+linux_amd64: export GOOS=linux
+linux_amd64: export GOARCH=amd64
 linux_arm: export GOOS=linux
 linux_arm: export GOARCH=arm
 linux_arm: export GOARM=6
 linux_arm64: export GOOS=linux
 linux_arm64: export GOARCH=arm64
-darwin: export GOOS=darwin
-darwin: export GOARCH=amd64
+darwin_amd64: export GOOS=darwin
+darwin_amd64: export GOARCH=amd64
 darwin_arm64: export GOOS=darwin
 darwin_arm64: export GOARCH=arm64
-windows: export GOOS=windows
-windows: export GOARCH=amd64
+windows_amd64: export GOOS=windows
+windows_amd64: export GOARCH=amd64
 windows_arm: export GOOS=windows
 windows_arm: export GOARCH=arm
 windows_arm64: export GOOS=windows
 windows_arm64: export GOARCH=arm64
 
-.PHONY: all linux linux_arm linux_arm64 darwin darwin_arm64 windows windows_arm windows_arm64 clean
+.PHONY: all linux_amd64 linux_arm linux_arm64 darwin_amd64 darwin_arm64 windows_amd64 windows_arm windows_arm64 clean
 
-all: linux linux_arm linux_arm64 darwin darwin_arm64 windows windows_arm windows_arm64
+all: linux_amd64 linux_arm linux_arm64 darwin_amd64 darwin_arm64 windows_amd64 windows_arm windows_arm64
 
-linux:
+linux_amd64:
 	go build $(LDFLAGS)
 	mkdir -p release
 	rm -f release/aws-rotate-key-${VERSION}-${GOOS}_${GOARCH}.zip
@@ -41,7 +41,7 @@ linux_arm64:
 	rm -f release/aws-rotate-key-${VERSION}-${GOOS}_${GOARCH}.zip
 	zip release/aws-rotate-key-${VERSION}-${GOOS}_${GOARCH}.zip aws-rotate-key
 
-darwin:
+darwin_amd64:
 	go build $(LDFLAGS)
 	mkdir -p release
 	rm -f release/aws-rotate-key-${VERSION}-${GOOS}_${GOARCH}.zip
@@ -53,7 +53,7 @@ darwin_arm64:
 	rm -f release/aws-rotate-key-${VERSION}-${GOOS}_${GOARCH}.zip
 	zip release/aws-rotate-key-${VERSION}-${GOOS}_${GOARCH}.zip aws-rotate-key
 
-windows:
+windows_amd64:
 	go build $(LDFLAGS)
 	mkdir -p release
 	rm -f release/aws-rotate-key-${VERSION}-${GOOS}_${GOARCH}.zip

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 VERSION = 1.0.8
 LDFLAGS = -ldflags '-s -w' -gcflags=-trimpath=${PWD} -asmflags=-trimpath=${PWD}
-GOARCH = amd64
 
 linux: export GOOS=linux
+linux: export GOARCH=amd64
 linux_arm: export GOOS=linux
 linux_arm: export GOARCH=arm
 linux_arm: export GOARM=6
 linux_arm64: export GOOS=linux
 linux_arm64: export GOARCH=arm64
 darwin: export GOOS=darwin
+darwin: export GOARCH=amd64
 darwin_arm64: export GOOS=darwin
 darwin_arm64: export GOARCH=arm64
 windows: export GOOS=windows
+windows: export GOARCH=amd64
 windows_arm: export GOOS=windows
 windows_arm: export GOARCH=arm
 windows_arm64: export GOOS=windows


### PR DESCRIPTION
Hello there!

I've noticed that the windows `amd64` binary is actually built for `arm` (you can use [this](https://docs.microsoft.com/en-us/sysinternals/downloads/sigcheck) to verify yourself). I'm not a makefile expert, but I'm assuming the `GOARCH = amd64` line at the top didn't work, so my proposed fix is to be explicit about the arch even for amd64.

I've tested my change, and it does generate binaries for the correct platforms 🚀 